### PR TITLE
Revamp/model helper discard

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ If you're only accepting a single file upload, change it to
 
 ``` ruby
 def user_params
-  params.require(:user).permit(:name, :photo)
+  params.require(:user).permit(:name, :photo, attaches_discarded: [])
 end
 ```
 
@@ -95,9 +95,11 @@ If you're accepting multiple file uploads, change it to
 
 ``` ruby
 def user_params
-  params.require(:user).permit(:name, photos: [])
+  params.require(:user).permit(:name, photos: [], attaches_discarded: [])
 end
 ```
+
+NOTE: You do not have to manage `params[:attaches_discarded]` yourself. It is automatically managed for you between the frontend javascript and the ActiveRecord integration: files that are discarded will be removed from the attache server when you update or destroy your model.
 
 ### Show
 
@@ -116,9 +118,7 @@ or
 
 ### Environment configs
 
-`ATTACHE_UPLOAD_URL` points to the attache server upload url. e.g. `http://localhost:9292/upload`
-
-`ATTACHE_DOWNLOAD_URL` points to url prefix for downloading the resized images, e.g. `http://cdn.lvh.me:9292/view`
+`ATTACHE_URL` points to the attache server. e.g. `http://localhost:9292`
 
 `ATTACHE_UPLOAD_DURATION` refers to the number of seconds before a signed upload request is considered expired, e.g. `600`
 

--- a/app/assets/javascripts/attache.js
+++ b/app/assets/javascripts/attache.js
@@ -1,4 +1,4 @@
 //= require attache/cors_upload
-//= require attache/file_input
 //= require attache/bootstrap3
+//= require attache/file_input
 //= require attache/ujs

--- a/app/assets/javascripts/attache/bootstrap3.js
+++ b/app/assets/javascripts/attache/bootstrap3.js
@@ -46,3 +46,17 @@ if (typeof AttacheFilePreview === 'undefined') {
   });
 
 }
+
+if (typeof AttachePlaceholder === 'undefined') {
+
+  var AttachePlaceholder = React.createClass({displayName: "AttachePlaceholder",
+    render: function() {
+      return (
+        React.createElement("div", {className: "attache-file-preview"}, 
+          React.createElement("img", {src: this.props.src})
+        )
+      );
+    }
+  });
+
+}

--- a/app/assets/javascripts/attache/bootstrap3.js
+++ b/app/assets/javascripts/attache/bootstrap3.js
@@ -60,3 +60,15 @@ if (typeof AttachePlaceholder === 'undefined') {
   });
 
 }
+
+if (typeof AttacheHeader === 'undefined') {
+
+  var AttacheHeader = React.createClass({displayName: "AttacheHeader",
+    render: function() {
+      return (
+        React.createElement("noscript", null)
+      );
+    }
+  });
+
+}

--- a/app/assets/javascripts/attache/bootstrap3.js.jsx
+++ b/app/assets/javascripts/attache/bootstrap3.js.jsx
@@ -60,3 +60,15 @@ if (typeof AttachePlaceholder === 'undefined') {
   });
 
 }
+
+if (typeof AttacheHeader === 'undefined') {
+
+  var AttacheHeader = React.createClass({
+    render: function() {
+      return (
+        <noscript />
+      );
+    }
+  });
+
+}

--- a/app/assets/javascripts/attache/bootstrap3.js.jsx
+++ b/app/assets/javascripts/attache/bootstrap3.js.jsx
@@ -46,3 +46,17 @@ if (typeof AttacheFilePreview === 'undefined') {
   });
 
 }
+
+if (typeof AttachePlaceholder === 'undefined') {
+
+  var AttachePlaceholder = React.createClass({
+    render: function() {
+      return (
+        <div className="attache-file-preview">
+          <img src={this.props.src} />
+        </div>
+      );
+    }
+  });
+
+}

--- a/app/assets/javascripts/attache/cors_upload.js
+++ b/app/assets/javascripts/attache/cors_upload.js
@@ -14,7 +14,7 @@ var AttacheCORSUpload = (function() {
   }
 
   AttacheCORSUpload.prototype.handleFileSelect = function(file_element) {
-    var f, files, output, _i, _len, _results, url, $ele;
+    var f, files, output, _i, _len, _results, url, $ele, prefix;
     $ele = $(file_element);
     url = $ele.data('uploadurl');
     if ($ele.data('hmac')) {
@@ -25,12 +25,13 @@ var AttacheCORSUpload = (function() {
             ""
     }
 
+    prefix = Date.now() + "_";
     files = file_element.files;
     output = [];
     _results = [];
     for (_i = 0, _len = files.length; _i < _len; _i++) {
       f = files[_i];
-      f.uid = counter++;
+      f.uid = prefix + (counter++);
       this.onProgress(f.uid, { filename: f.name, percentLoaded: 0, bytesLoaded: 0, bytesTotal: f.size });
       _results.push(this.performUpload(f, url));
     }

--- a/app/assets/javascripts/attache/file_input.js
+++ b/app/assets/javascripts/attache/file_input.js
@@ -20,7 +20,8 @@ var AttacheFileInput = React.createClass({displayName: "AttacheFileInput",
     var file_element = this.getDOMNode().firstChild;
     // user cancelled file chooser dialog. ignore
     if (file_element.files.length == 0) return;
-    this.state.files = {};
+    if (! this.props.multiple) this.state.files = {};
+
     this.setState(this.state);
     // upload the file via CORS
     var that = this;
@@ -54,6 +55,7 @@ var AttacheFileInput = React.createClass({displayName: "AttacheFileInput",
         parts.splice(parts.length-1, 0, encodeURIComponent(that.props['data-geometry'] || '128x128#'));
         result.src = that.props['data-downloadurl'] + '/' + parts.join('/');
         result.filename = result.src.split('/').pop().split(/[#?]/).shift();
+        result.multiple = that.props.multiple;
       }
       previews.push(
         React.createElement("div", {className: "attache-file-input"}, 
@@ -64,15 +66,17 @@ var AttacheFileInput = React.createClass({displayName: "AttacheFileInput",
     });
 
     var placeholders = [];
-    if (previews.length == 0 && this.props['data-placeholder']) $.each(JSON.parse(this.props['data-placeholder']), function(uid, src) {
+    if (previews.length == 0 && that.props['data-placeholder']) $.each(JSON.parse(that.props['data-placeholder']), function(uid, src) {
       placeholders.push(
-        React.createElement(AttachePlaceholder, {src: src})
+        React.createElement(AttachePlaceholder, React.__spread({},   that.props, {src: src}))
       );
     });
 
+    var className = ["attache-file-selector", "attache-placeholders-count-" + placeholders.length, "attache-previews-count-" + previews.length, this.props['data-classname']].join(' ').trim();
     return (
-      React.createElement("label", {htmlFor: this.props.id, className: "attache-file-selector"}, 
-        React.createElement("input", React.__spread({type: "file"},  this.props, {onChange: this.onChange})), 
+      React.createElement("label", {htmlFor: that.props.id, className: className}, 
+        React.createElement("input", React.__spread({type: "file"},  that.props, {onChange: this.onChange})), 
+        React.createElement(AttacheHeader, React.__spread({},  that.props)), 
         previews, 
         placeholders
       )

--- a/app/assets/javascripts/attache/file_input.js
+++ b/app/assets/javascripts/attache/file_input.js
@@ -3,7 +3,7 @@ var AttacheFileInput = React.createClass({displayName: "AttacheFileInput",
   getInitialState: function() {
     var files = {};
     if (this.props['data-value']) $.each(JSON.parse(this.props['data-value']), function(uid, json) {
-      if (json) files[uid] = { path: json };
+      if (json) files[uid] = json;
     });
     return {files: files};
   },
@@ -47,9 +47,12 @@ var AttacheFileInput = React.createClass({displayName: "AttacheFileInput",
   render: function() {
     var that = this;
 
+    var Header = eval(this.props['data-header-component'] || 'AttacheHeader');
+    var Preview = eval(this.props['data-preview-component'] || 'AttacheFilePreview');
+    var Placeholder = eval(this.props['data-placeholder-component'] || 'AttachePlaceholder');
+
     var previews = [];
     $.each(that.state.files, function(key, result) {
-      var json = JSON.stringify(result);
       if (result.path) {
         var parts = result.path.split('/');
         parts.splice(parts.length-1, 0, encodeURIComponent(that.props['data-geometry'] || '128x128#'));
@@ -57,10 +60,11 @@ var AttacheFileInput = React.createClass({displayName: "AttacheFileInput",
         result.filename = result.src.split('/').pop().split(/[#?]/).shift();
         result.multiple = that.props.multiple;
       }
+      var json = JSON.stringify(result);
       previews.push(
         React.createElement("div", {className: "attache-file-input"}, 
-          React.createElement("input", {type: "hidden", name: that.props.name, value: result.path, readOnly: "true"}), 
-          React.createElement(AttacheFilePreview, React.__spread({},  result, {key: key, onRemove: that.onRemove.bind(that, key)}))
+          React.createElement("input", {type: "hidden", name: that.props.name, value: json, readOnly: "true"}), 
+          React.createElement(Preview, React.__spread({},  result, {key: key, onRemove: that.onRemove.bind(that, key)}))
         )
       );
     });
@@ -68,7 +72,7 @@ var AttacheFileInput = React.createClass({displayName: "AttacheFileInput",
     var placeholders = [];
     if (previews.length == 0 && that.props['data-placeholder']) $.each(JSON.parse(that.props['data-placeholder']), function(uid, src) {
       placeholders.push(
-        React.createElement(AttachePlaceholder, React.__spread({},   that.props, {src: src}))
+        React.createElement(Placeholder, React.__spread({},   that.props, {src: src}))
       );
     });
 
@@ -76,7 +80,8 @@ var AttacheFileInput = React.createClass({displayName: "AttacheFileInput",
     return (
       React.createElement("label", {htmlFor: that.props.id, className: className}, 
         React.createElement("input", React.__spread({type: "file"},  that.props, {onChange: this.onChange})), 
-        React.createElement(AttacheHeader, React.__spread({},  that.props)), 
+        React.createElement("input", {type: "hidden", name: that.props.name, value: ""}), 
+        React.createElement(Header, React.__spread({},  that.props)), 
         previews, 
         placeholders
       )

--- a/app/assets/javascripts/attache/file_input.js
+++ b/app/assets/javascripts/attache/file_input.js
@@ -2,18 +2,18 @@ var AttacheFileInput = React.createClass({displayName: "AttacheFileInput",
 
   getInitialState: function() {
     var files = {};
-    var array = ([].concat(JSON.parse(this.props['data-value'])));
-    $.each(array, function(uid, json) {
+    if (this.props['data-value']) $.each(JSON.parse(this.props['data-value']), function(uid, json) {
       if (json) files[uid] = { path: json };
     });
     return {files: files};
   },
 
   onRemove: function(uid, e) {
-    delete this.state.files[uid];
-    this.setState(this.state);
     e.preventDefault();
     e.stopPropagation();
+
+    delete this.state.files[uid];
+    this.setState(this.state);
   },
 
   onChange: function() {
@@ -45,6 +45,7 @@ var AttacheFileInput = React.createClass({displayName: "AttacheFileInput",
 
   render: function() {
     var that = this;
+
     var previews = [];
     $.each(that.state.files, function(key, result) {
       var json = JSON.stringify(result);
@@ -61,10 +62,19 @@ var AttacheFileInput = React.createClass({displayName: "AttacheFileInput",
         )
       );
     });
+
+    var placeholders = [];
+    if (previews.length == 0 && this.props['data-placeholder']) $.each(JSON.parse(this.props['data-placeholder']), function(uid, src) {
+      placeholders.push(
+        React.createElement(AttachePlaceholder, {src: src})
+      );
+    });
+
     return (
       React.createElement("label", {htmlFor: this.props.id, className: "attache-file-selector"}, 
         React.createElement("input", React.__spread({type: "file"},  this.props, {onChange: this.onChange})), 
-        previews
+        previews, 
+        placeholders
       )
     );
   }

--- a/app/assets/javascripts/attache/file_input.js
+++ b/app/assets/javascripts/attache/file_input.js
@@ -5,14 +5,19 @@ var AttacheFileInput = React.createClass({displayName: "AttacheFileInput",
     if (this.props['data-value']) $.each(JSON.parse(this.props['data-value']), function(uid, json) {
       if (json) files[uid] = json;
     });
-    return {files: files};
+    return {files: files, attaches_discarded: []};
   },
 
   onRemove: function(uid, e) {
     e.preventDefault();
     e.stopPropagation();
 
+    var fieldname = this.getDOMNode().firstChild.name;                           // when   'user[avatar]'
+    var newfield  = fieldname.replace(/\w+\](\[\]|)$/, 'attaches_discarded][]'); // become 'user[attaches_discarded][]'
+
+    this.state.attaches_discarded.push({ fieldname: newfield, path: this.state.files[uid].path });
     delete this.state.files[uid];
+
     this.setState(this.state);
   },
 
@@ -76,6 +81,13 @@ var AttacheFileInput = React.createClass({displayName: "AttacheFileInput",
       );
     });
 
+    var discards = [];
+    $.each(that.state.attaches_discarded, function(index, discard) {
+      discards.push(
+        React.createElement("input", {type: "hidden", name: discard.fieldname, value: discard.path})
+      );
+    });
+
     var className = ["attache-file-selector", "attache-placeholders-count-" + placeholders.length, "attache-previews-count-" + previews.length, this.props['data-classname']].join(' ').trim();
     return (
       React.createElement("label", {htmlFor: that.props.id, className: className}, 
@@ -83,7 +95,8 @@ var AttacheFileInput = React.createClass({displayName: "AttacheFileInput",
         React.createElement("input", {type: "hidden", name: that.props.name, value: ""}), 
         React.createElement(Header, React.__spread({},  that.props)), 
         previews, 
-        placeholders
+        placeholders, 
+        discards
       )
     );
   }

--- a/app/assets/javascripts/attache/file_input.js.jsx
+++ b/app/assets/javascripts/attache/file_input.js.jsx
@@ -20,7 +20,8 @@ var AttacheFileInput = React.createClass({
     var file_element = this.getDOMNode().firstChild;
     // user cancelled file chooser dialog. ignore
     if (file_element.files.length == 0) return;
-    this.state.files = {};
+    if (! this.props.multiple) this.state.files = {};
+
     this.setState(this.state);
     // upload the file via CORS
     var that = this;
@@ -54,6 +55,7 @@ var AttacheFileInput = React.createClass({
         parts.splice(parts.length-1, 0, encodeURIComponent(that.props['data-geometry'] || '128x128#'));
         result.src = that.props['data-downloadurl'] + '/' + parts.join('/');
         result.filename = result.src.split('/').pop().split(/[#?]/).shift();
+        result.multiple = that.props.multiple;
       }
       previews.push(
         <div className="attache-file-input">
@@ -64,15 +66,17 @@ var AttacheFileInput = React.createClass({
     });
 
     var placeholders = [];
-    if (previews.length == 0 && this.props['data-placeholder']) $.each(JSON.parse(this.props['data-placeholder']), function(uid, src) {
+    if (previews.length == 0 && that.props['data-placeholder']) $.each(JSON.parse(that.props['data-placeholder']), function(uid, src) {
       placeholders.push(
-        <AttachePlaceholder src={src} />
+        <AttachePlaceholder  {...that.props} src={src} />
       );
     });
 
+    var className = ["attache-file-selector", "attache-placeholders-count-" + placeholders.length, "attache-previews-count-" + previews.length, this.props['data-classname']].join(' ').trim();
     return (
-      <label htmlFor={this.props.id} className="attache-file-selector">
-        <input type="file" {...this.props} onChange={this.onChange}/>
+      <label htmlFor={that.props.id} className={className}>
+        <input type="file" {...that.props} onChange={this.onChange}/>
+        <AttacheHeader {...that.props} />
         {previews}
         {placeholders}
       </label>

--- a/app/assets/javascripts/attache/file_input.js.jsx
+++ b/app/assets/javascripts/attache/file_input.js.jsx
@@ -5,14 +5,19 @@ var AttacheFileInput = React.createClass({
     if (this.props['data-value']) $.each(JSON.parse(this.props['data-value']), function(uid, json) {
       if (json) files[uid] = json;
     });
-    return {files: files};
+    return {files: files, attaches_discarded: []};
   },
 
   onRemove: function(uid, e) {
     e.preventDefault();
     e.stopPropagation();
 
+    var fieldname = this.getDOMNode().firstChild.name;                           // when   'user[avatar]'
+    var newfield  = fieldname.replace(/\w+\](\[\]|)$/, 'attaches_discarded][]'); // become 'user[attaches_discarded][]'
+
+    this.state.attaches_discarded.push({ fieldname: newfield, path: this.state.files[uid].path });
     delete this.state.files[uid];
+
     this.setState(this.state);
   },
 
@@ -76,6 +81,13 @@ var AttacheFileInput = React.createClass({
       );
     });
 
+    var discards = [];
+    $.each(that.state.attaches_discarded, function(index, discard) {
+      discards.push(
+        <input type="hidden" name={discard.fieldname} value={discard.path} />
+      );
+    });
+
     var className = ["attache-file-selector", "attache-placeholders-count-" + placeholders.length, "attache-previews-count-" + previews.length, this.props['data-classname']].join(' ').trim();
     return (
       <label htmlFor={that.props.id} className={className}>
@@ -84,6 +96,7 @@ var AttacheFileInput = React.createClass({
         <Header {...that.props} />
         {previews}
         {placeholders}
+        {discards}
       </label>
     );
   }

--- a/app/assets/javascripts/attache/file_input.js.jsx
+++ b/app/assets/javascripts/attache/file_input.js.jsx
@@ -3,7 +3,7 @@ var AttacheFileInput = React.createClass({
   getInitialState: function() {
     var files = {};
     if (this.props['data-value']) $.each(JSON.parse(this.props['data-value']), function(uid, json) {
-      if (json) files[uid] = { path: json };
+      if (json) files[uid] = json;
     });
     return {files: files};
   },
@@ -47,9 +47,12 @@ var AttacheFileInput = React.createClass({
   render: function() {
     var that = this;
 
+    var Header = eval(this.props['data-header-component'] || 'AttacheHeader');
+    var Preview = eval(this.props['data-preview-component'] || 'AttacheFilePreview');
+    var Placeholder = eval(this.props['data-placeholder-component'] || 'AttachePlaceholder');
+
     var previews = [];
     $.each(that.state.files, function(key, result) {
-      var json = JSON.stringify(result);
       if (result.path) {
         var parts = result.path.split('/');
         parts.splice(parts.length-1, 0, encodeURIComponent(that.props['data-geometry'] || '128x128#'));
@@ -57,10 +60,11 @@ var AttacheFileInput = React.createClass({
         result.filename = result.src.split('/').pop().split(/[#?]/).shift();
         result.multiple = that.props.multiple;
       }
+      var json = JSON.stringify(result);
       previews.push(
         <div className="attache-file-input">
-          <input type="hidden" name={that.props.name} value={result.path} readOnly="true" />
-          <AttacheFilePreview {...result} key={key} onRemove={that.onRemove.bind(that, key)}/>
+          <input type="hidden" name={that.props.name} value={json} readOnly="true" />
+          <Preview {...result} key={key} onRemove={that.onRemove.bind(that, key)}/>
         </div>
       );
     });
@@ -68,7 +72,7 @@ var AttacheFileInput = React.createClass({
     var placeholders = [];
     if (previews.length == 0 && that.props['data-placeholder']) $.each(JSON.parse(that.props['data-placeholder']), function(uid, src) {
       placeholders.push(
-        <AttachePlaceholder  {...that.props} src={src} />
+        <Placeholder  {...that.props} src={src} />
       );
     });
 
@@ -76,7 +80,8 @@ var AttacheFileInput = React.createClass({
     return (
       <label htmlFor={that.props.id} className={className}>
         <input type="file" {...that.props} onChange={this.onChange}/>
-        <AttacheHeader {...that.props} />
+        <input type="hidden" name={that.props.name} value="" />
+        <Header {...that.props} />
         {previews}
         {placeholders}
       </label>

--- a/app/assets/javascripts/attache/file_input.js.jsx
+++ b/app/assets/javascripts/attache/file_input.js.jsx
@@ -2,18 +2,18 @@ var AttacheFileInput = React.createClass({
 
   getInitialState: function() {
     var files = {};
-    var array = ([].concat(JSON.parse(this.props['data-value'])));
-    $.each(array, function(uid, json) {
+    if (this.props['data-value']) $.each(JSON.parse(this.props['data-value']), function(uid, json) {
       if (json) files[uid] = { path: json };
     });
     return {files: files};
   },
 
   onRemove: function(uid, e) {
-    delete this.state.files[uid];
-    this.setState(this.state);
     e.preventDefault();
     e.stopPropagation();
+
+    delete this.state.files[uid];
+    this.setState(this.state);
   },
 
   onChange: function() {
@@ -45,6 +45,7 @@ var AttacheFileInput = React.createClass({
 
   render: function() {
     var that = this;
+
     var previews = [];
     $.each(that.state.files, function(key, result) {
       var json = JSON.stringify(result);
@@ -61,10 +62,19 @@ var AttacheFileInput = React.createClass({
         </div>
       );
     });
+
+    var placeholders = [];
+    if (previews.length == 0 && this.props['data-placeholder']) $.each(JSON.parse(this.props['data-placeholder']), function(uid, src) {
+      placeholders.push(
+        <AttachePlaceholder src={src} />
+      );
+    });
+
     return (
       <label htmlFor={this.props.id} className="attache-file-selector">
         <input type="file" {...this.props} onChange={this.onChange}/>
         {previews}
+        {placeholders}
       </label>
     );
   }

--- a/lib/attache_rails.rb
+++ b/lib/attache_rails.rb
@@ -1,44 +1,8 @@
-require "attache_rails/engine"
-
 module AttacheRails
-  module Helper
-    ATTACHE_UPLOAD_URL   = ENV.fetch('ATTACHE_UPLOAD_URL')   { 'http://localhost:9292/upload' }
-    ATTACHE_DOWNLOAD_URL = ENV.fetch('ATTACHE_DOWNLOAD_URL') { 'http://localhost:9292/view' }
-    ATTACHE_UPLOAD_DURATION = ENV.fetch('ATTACHE_UPLOAD_DURATION') { '600' }.to_i # 10 minutes
-
-    def attache_urls(json, geometry)
-      array = json.kind_of?(Array) ? json : [*json]
-      array.collect do |path|
-        download_url = ATTACHE_DOWNLOAD_URL
-        prefix, basename = File.split(path)
-        [download_url, prefix, CGI.escape(geometry), basename].join('/').tap do |url|
-          yield url if block_given?
-        end
-      end
-    end
-
-    def attache_options(geometry, current_value, placeholder = nil, data_attrs = nil)
-      auth = if ENV['ATTACHE_SECRET_KEY']
-        uuid = SecureRandom.uuid
-        expiration = (Time.now + ATTACHE_UPLOAD_DURATION).to_i
-        hmac = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), ENV['ATTACHE_SECRET_KEY'], "#{uuid}#{expiration}")
-        { uuid: uuid, expiration: expiration, hmac: hmac }
-      else
-        {}
-      end
-
-      {
-        class: 'enable-attache',
-        data: {
-          geometry: geometry,
-          value: [*current_value],
-          placeholder: [*placeholder],
-          uploadurl: ATTACHE_UPLOAD_URL,
-          downloadurl: ATTACHE_DOWNLOAD_URL,
-        }.merge(data_attrs || {}).merge(auth),
-      }
-    end
-  end
+  ATTACHE_UPLOAD_URL      = ENV.fetch('ATTACHE_UPLOAD_URL')      { 'http://localhost:9292/upload' }
+  ATTACHE_DOWNLOAD_URL    = ENV.fetch('ATTACHE_DOWNLOAD_URL')    { 'http://localhost:9292/view' }
+  ATTACHE_UPLOAD_DURATION = ENV.fetch('ATTACHE_UPLOAD_DURATION') { '600' }.to_i # signed upload form expires in 10 minutes
 end
 
-ActionView::Base.send(:include, AttacheRails::Helper)
+require "attache_rails/engine"
+require "attache_rails/model"

--- a/lib/attache_rails.rb
+++ b/lib/attache_rails.rb
@@ -1,7 +1,9 @@
 module AttacheRails
-  ATTACHE_UPLOAD_URL      = ENV.fetch('ATTACHE_UPLOAD_URL')      { 'http://localhost:9292/upload' }
-  ATTACHE_DOWNLOAD_URL    = ENV.fetch('ATTACHE_DOWNLOAD_URL')    { 'http://localhost:9292/view' }
-  ATTACHE_UPLOAD_DURATION = ENV.fetch('ATTACHE_UPLOAD_DURATION') { '600' }.to_i # signed upload form expires in 10 minutes
+  ATTACHE_URL             = ENV.fetch('ATTACHE_URL')             { "http://localhost:9292" }
+  ATTACHE_UPLOAD_URL      = ENV.fetch('ATTACHE_UPLOAD_URL')      { "#{ATTACHE_URL}/upload" }
+  ATTACHE_DOWNLOAD_URL    = ENV.fetch('ATTACHE_DOWNLOAD_URL')    { "#{ATTACHE_URL}/view" }
+  ATTACHE_DELETE_URL      = ENV.fetch('ATTACHE_DELETE_URL')      { "#{ATTACHE_URL}/delete" }
+  ATTACHE_UPLOAD_DURATION = ENV.fetch('ATTACHE_UPLOAD_DURATION') { "600" }.to_i # signed upload form expires in 10 minutes
 end
 
 require "attache_rails/engine"

--- a/lib/attache_rails.rb
+++ b/lib/attache_rails.rb
@@ -17,7 +17,7 @@ module AttacheRails
       end
     end
 
-    def attache_options(geometry, current_value)
+    def attache_options(geometry, current_value, placeholder = nil, data_attrs = nil)
       auth = if ENV['ATTACHE_SECRET_KEY']
         uuid = SecureRandom.uuid
         expiration = (Time.now + ATTACHE_UPLOAD_DURATION).to_i
@@ -32,9 +32,10 @@ module AttacheRails
         data: {
           geometry: geometry,
           value: [*current_value],
+          placeholder: [*placeholder],
           uploadurl: ATTACHE_UPLOAD_URL,
           downloadurl: ATTACHE_DOWNLOAD_URL,
-        }.merge(auth),
+        }.merge(data_attrs || {}).merge(auth),
       }
     end
   end

--- a/lib/attache_rails/model.rb
+++ b/lib/attache_rails/model.rb
@@ -1,15 +1,18 @@
+require "net/http"
+require "uri"
+
 module AttacheRails
   module Utils
     class << self
-      def with_url(json_string, geometry)
+      def attache_url_for(json_string, geometry)
         JSON.parse(json_string).tap do |attrs|
           prefix, basename = File.split(attrs['path'])
           attrs['url'] = [ATTACHE_DOWNLOAD_URL, prefix, CGI.escape(geometry), basename].join('/')
         end
       end
 
-      def attache_options(geometry, current_value, options)
-        auth = if ENV['ATTACHE_SECRET_KEY']
+      def attache_auth_options
+        if ENV['ATTACHE_SECRET_KEY']
           uuid = SecureRandom.uuid
           expiration = (Time.now + ATTACHE_UPLOAD_DURATION).to_i
           hmac = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), ENV['ATTACHE_SECRET_KEY'], "#{uuid}#{expiration}")
@@ -17,7 +20,9 @@ module AttacheRails
         else
           {}
         end
+      end
 
+      def attache_options(geometry, current_value, options)
         {
           multiple: options[:multiple],
           class: 'enable-attache',
@@ -27,7 +32,7 @@ module AttacheRails
             placeholder: [*options[:placeholder]],
             uploadurl: ATTACHE_UPLOAD_URL,
             downloadurl: ATTACHE_DOWNLOAD_URL,
-          }.merge(options[:data_attrs] || {}).merge(auth),
+          }.merge(options[:data_attrs] || {}).merge(attache_auth_options),
         }
       end
     end
@@ -35,15 +40,33 @@ module AttacheRails
   module Model
     def self.included(base)
       base.extend ClassMethods
+      base.class_eval do
+        attr_accessor :attaches_discarded
+        after_commit  :attaches_discard!, if: :attaches_discarded
+      end
     end
 
+    def attaches_discard!(files = attaches_discarded)
+      if files.present?
+        logger.info "DELETE #{files.inspect}"
+        Net::HTTP.post_form(
+          URI.parse(ATTACHE_DELETE_URL),
+          Utils.attache_auth_options.merge(paths: files.join("\n"))
+        )
+      end
+    end
 
     module ClassMethods
       def has_one_attache(name)
         serialize name, JSON
         define_method "#{name}_options",    -> (geometry, options = {}) { Utils.attache_options(geometry, [self.send("#{name}_attributes", geometry)], multiple: false, **options) }
         define_method "#{name}_url",        -> (geometry) {               self.send("#{name}_attributes", geometry).try(:[], 'url') }
-        define_method "#{name}_attributes", -> (geometry) {               str = self.send(name); Utils.with_url(str, geometry) if str; }
+        define_method "#{name}_attributes", -> (geometry) {               str = self.send(name); Utils.attache_url_for(str, geometry) if str; }
+        define_method "#{name}_discard",    -> do
+          self.attaches_discarded ||= []
+          self.attaches_discarded.push(self.send("#{name}_attributes", 'original')['path'])
+        end
+        after_destroy "#{name}_discard"
       end
 
       def has_many_attaches(name)
@@ -52,9 +75,14 @@ module AttacheRails
         define_method "#{name}_urls",       -> (geometry) {               self.send("#{name}_attributes", geometry).collect {|attrs| attrs['url'] } }
         define_method "#{name}_attributes", -> (geometry) {
           (self.send(name) || []).inject([]) do |sum, str|
-            sum + (str.blank? ? [] : [Utils.with_url(str, geometry)])
+            sum + (str.blank? ? [] : [Utils.attache_url_for(str, geometry)])
           end
         }
+        define_method "#{name}_discard",    -> do
+          self.attaches_discarded ||= []
+          self.send("#{name}_attributes", 'original').each {|attrs| self.attaches_discarded.push(attrs['path']) }
+        end
+        after_destroy "#{name}_discard"
       end
     end
   end

--- a/lib/attache_rails/model.rb
+++ b/lib/attache_rails/model.rb
@@ -1,0 +1,63 @@
+module AttacheRails
+  module Utils
+    class << self
+      def with_url(json_string, geometry)
+        JSON.parse(json_string).tap do |attrs|
+          prefix, basename = File.split(attrs['path'])
+          attrs['url'] = [ATTACHE_DOWNLOAD_URL, prefix, CGI.escape(geometry), basename].join('/')
+        end
+      end
+
+      def attache_options(geometry, current_value, options)
+        auth = if ENV['ATTACHE_SECRET_KEY']
+          uuid = SecureRandom.uuid
+          expiration = (Time.now + ATTACHE_UPLOAD_DURATION).to_i
+          hmac = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), ENV['ATTACHE_SECRET_KEY'], "#{uuid}#{expiration}")
+          { uuid: uuid, expiration: expiration, hmac: hmac }
+        else
+          {}
+        end
+
+        {
+          multiple: options[:multiple],
+          class: 'enable-attache',
+          data: {
+            geometry: geometry,
+            value: [*current_value],
+            placeholder: [*options[:placeholder]],
+            uploadurl: ATTACHE_UPLOAD_URL,
+            downloadurl: ATTACHE_DOWNLOAD_URL,
+          }.merge(options[:data_attrs] || {}).merge(auth),
+        }
+      end
+    end
+  end
+  module Model
+    def self.included(base)
+      base.extend ClassMethods
+    end
+
+
+    module ClassMethods
+      def has_one_attache(name)
+        serialize name, JSON
+        define_method "#{name}_options",    -> (geometry, options = {}) { Utils.attache_options(geometry, [self.send("#{name}_attributes", geometry)], multiple: false, **options) }
+        define_method "#{name}_url",        -> (geometry) {               self.send("#{name}_attributes", geometry).try(:[], 'url') }
+        define_method "#{name}_attributes", -> (geometry) {               str = self.send(name); Utils.with_url(str, geometry) if str; }
+      end
+
+      def has_many_attaches(name)
+        serialize name, JSON
+        define_method "#{name}_options",    -> (geometry, options = {}) { Utils.attache_options(geometry, self.send("#{name}_attributes", geometry), multiple: true, **options) }
+        define_method "#{name}_urls",       -> (geometry) {               self.send("#{name}_attributes", geometry).collect {|attrs| attrs['url'] } }
+        define_method "#{name}_attributes", -> (geometry) {
+          (self.send(name) || []).inject([]) do |sum, str|
+            sum + (str.blank? ? [] : [Utils.with_url(str, geometry)])
+          end
+        }
+      end
+    end
+  end
+end
+
+ActiveRecord::Base.send(:include, AttacheRails::Model)

--- a/lib/attache_rails/version.rb
+++ b/lib/attache_rails/version.rb
@@ -1,3 +1,3 @@
 module AttacheRails
-  VERSION = "0.0.7"
+  VERSION = "0.1.0"
 end

--- a/lib/attache_rails/version.rb
+++ b/lib/attache_rails/version.rb
@@ -1,3 +1,3 @@
 module AttacheRails
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end


### PR DESCRIPTION
Changes
- moving to storing entire `json` response per file uploaded (previously only storing the `path`). thus attributes like file size, content type are readily available for manipulation
- moving `multiple` file input to _append_ files to the previously uploaded list of files (previously resetting the array). users can manually remove files they don't want, not necessary to reset the existing array
- using model helper methods e.g. `has_many_attaches` instead of view helpers. righting a wrong design.
- adding `attaches_discarded` virtual attribute in model to manage the deletion of those unreferenced files.
  - front-end code will add `path` into the `[attaches_discarded][]` params when a file is removed.
  - on save, the model will ask `attache` server to [remove all files in `attaches_discarded`](https://github.com/choonkeat/attache#delete)
  - controller will need to allow `attaches_discarded: []` in its strong params definition
