### PR TITLE
Refactor/store as hash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'attache_api', path: '../attache_api'
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
+gem 'attache_api', path: '../attache_api'
 gemspec

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ or
 
 ### PostgreSQL
 
-Take advantage of the [json support](http://guides.rubyonrails.org/active_record_postgresql.html#json) by using the `json` column type instead
+Take advantage of the [json support](http://guides.rubyonrails.org/active_record_postgresql.html#json) by using the [`json` or `jsonb` column types](http://www.postgresql.org/docs/9.4/static/functions-json.html) instead
 
 ``` bash
 rails generate migration AddPhotoPathToUsers photo:json
@@ -164,7 +164,7 @@ If you're upgrading from V2, we have a generator that will create a migration fi
 rails g attache_rails:upgrade_v2_to_v3
 ```
 
-NOTE: It is highly recommended that developers verify the migration with a dump of the production data in a staging[] environment. Please take a look at the generated migration file.
+NOTE: It is highly recommended that developers verify the migration with a dump of the production data in a staging environment. Please take a look at the generated migration file.
 
 # License
 

--- a/attache_rails.gemspec
+++ b/attache_rails.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.files       = Dir["{app,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "rails", ">= 4.0.0"
+  s.add_dependency "attache_api"
 
   s.add_runtime_dependency 'httpclient'
 

--- a/lib/attache_rails/model.rb
+++ b/lib/attache_rails/model.rb
@@ -1,65 +1,21 @@
 require "cgi"
 require "uri"
 require "httpclient"
+require "attache/api/v1"
 
 module AttacheRails
   module Utils
     class << self
+      include Attache::API::V1
+
       def array(value)
         Array.wrap(value).reject(&:blank?)
       end
 
-      def attache_retry_doing(max_retries, retries = 0)
-        yield
-      rescue Exception
-        if (retries += 1) <= max_retries
-          sleep retries
-          retry
-        end
-        raise
-      end
-
-      def attache_upload_and_get_json(readable)
-        uri = URI.parse(ATTACHE_UPLOAD_URL)
-        original_filename = readable.try(:original_filename) ||
-                            readable.try(:path) && File.basename(readable.try(:path)) ||
-                            'noname'
-        uri.query = { file: original_filename, **attache_auth_options }.collect {|k,v|
-          CGI.escape(k.to_s) + "=" + CGI.escape(v.to_s)
-        }.join('&')
-        attache_retry_doing(3) { HTTPClient.post(uri, readable, {'Content-Type' => 'binary/octet-stream'}).body }
-      end
-
-      def attache_url_for(json_string, geometry)
+      def url_for(json_string, geometry)
         JSON.parse(json_string).tap do |attrs|
-          prefix, basename = File.split(attrs['path'])
-          attrs['url'] = [ATTACHE_DOWNLOAD_URL, prefix, CGI.escape(geometry), CGI.escape(basename)].join('/')
+          attrs['url'] = attache_url_for(attrs['path'], geometry)
         end
-      end
-
-      def attache_auth_options
-        if ENV['ATTACHE_SECRET_KEY']
-          uuid = SecureRandom.uuid
-          expiration = (Time.now + ATTACHE_UPLOAD_DURATION).to_i
-          hmac = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), ENV['ATTACHE_SECRET_KEY'], "#{uuid}#{expiration}")
-          { uuid: uuid, expiration: expiration, hmac: hmac }
-        else
-          {}
-        end
-      end
-
-      def attache_options(geometry, current_value, options)
-        {
-          multiple: options[:multiple],
-          class: 'enable-attache',
-          data: {
-            geometry: geometry,
-            value: [*current_value],
-            placeholder: [*options[:placeholder]],
-            uploadurl: ATTACHE_UPLOAD_URL,
-            downloadurl: ATTACHE_DOWNLOAD_URL,
-          }.merge(options[:data] || {}).merge(attache_auth_options),
-        }
       end
     end
   end
@@ -77,10 +33,7 @@ module AttacheRails
       files.uniq!
       if files.present?
         logger.info "DELETE #{files.inspect}"
-        HTTPClient.post_content(
-          URI.parse(ATTACHE_DELETE_URL),
-          Utils.attache_auth_options.merge(paths: files.join("\n"))
-        )
+        Utils.attache_delete(*files)
       end
     rescue Exception
       raise if ENV['ATTACHE_DISCARD_FAILURE_RAISE_ERROR']
@@ -92,9 +45,9 @@ module AttacheRails
         serialize name, JSON
         define_method "#{name}_options",    -> (geometry, options = {}) { Utils.attache_options(geometry, Utils.array(self.send("#{name}_attributes", geometry)), multiple: false, **options) }
         define_method "#{name}_url",        -> (geometry) {               self.send("#{name}_attributes", geometry).try(:[], 'url') }
-        define_method "#{name}_attributes", -> (geometry) {               str = self.send(name); Utils.attache_url_for(str, geometry) if str; }
+        define_method "#{name}_attributes", -> (geometry) {               str = self.send(name); Utils.url_for(str, geometry) if str; }
         define_method "#{name}=",           -> (value)    {
-          new_value = (value.respond_to?(:read) ? Utils.attache_upload_and_get_json(value) : value)
+          new_value = (value.respond_to?(:read) ? Utils.attache_upload(value) : value)
           okay = JSON.parse(new_value)['path'] rescue nil
           super(Utils.array(okay ? new_value : nil).first)
         }
@@ -121,12 +74,12 @@ module AttacheRails
         define_method "#{name}_urls",       -> (geometry) {               self.send("#{name}_attributes", geometry).collect {|attrs| attrs['url'] } }
         define_method "#{name}_attributes", -> (geometry) {
           (self.send(name) || []).inject([]) do |sum, str|
-            sum + Utils.array(str.present? && Utils.attache_url_for(str, geometry))
+            sum + Utils.array(str.present? && Utils.url_for(str, geometry))
           end
         }
         define_method "#{name}=",           -> (array)    {
           new_value = Utils.array(array).inject([]) {|sum,value|
-            hash = value.respond_to?(:read) ? Utils.attache_upload_and_get_json(value) : value
+            hash = value.respond_to?(:read) ? Utils.attache_upload(value) : value
             okay = JSON.parse(hash)['path'] rescue nil
             okay ? sum + [hash] : sum
           }

--- a/lib/attache_rails/model.rb
+++ b/lib/attache_rails/model.rb
@@ -1,35 +1,12 @@
 require "cgi"
 require "uri"
 require "httpclient"
-require "attache/api/v1"
+require "attache/api"
 
 module AttacheRails
-  module Utils
-    class << self
-      include Attache::API::V1
-
-      def array(value)
-        Array.wrap(value).reject(&:blank?)
-      end
-
-      def jsonify(value)
-        case value
-        when Hash
-          value
-        else
-          JSON.parse(value.to_s) rescue Hash.new
-        end
-      end
-
-      def url_for(json_string, geometry)
-        json_string.tap do |attrs|
-          attrs['url'] = attache_url_for(attrs['path'], geometry)
-        end
-      end
-    end
-  end
   module Model
     def self.included(base)
+      base.send(:include, Attache::API::Model)
       base.extend ClassMethods
       base.class_eval do
         attr_accessor :attaches_discarded
@@ -39,53 +16,13 @@ module AttacheRails
       end
     end
 
-    def attache_field_options(attr_value, geometry, options = {})
-      Utils.attache_options(geometry, attache_field_attributes(attr_value, geometry), **options)
-    end
-
-    def attache_field_urls(attr_value, geometry)
-      attache_field_attributes(attr_value, geometry).collect {|attrs| attrs['url']}
-    end
-
-    def attache_field_attributes(attr_value, geometry)
-      Utils.array(attr_value).inject([]) do |sum, obj|
-        sum + Utils.array(obj.present? && Utils.url_for(obj, geometry))
-      end
-    end
-
-    def attache_field_set(array)
-      new_value = Utils.array(array).inject([]) {|sum,value|
-        hash = Utils.jsonify(value.respond_to?(:read) && Utils.attache_upload(value) || value)
-        okay = hash.respond_to?(:[]) && (hash['path'] || hash[:path])
-        okay ? sum + [hash] : sum
-      }
-      Utils.array(new_value)
-    end
-
-    def attache_mark_for_discarding(old_value, new_value, attaches_discarded)
-      obsoleted = Utils.array(old_value).collect {|x| x['path'] } - Utils.array(new_value).collect {|x| x['path'] }
-      obsoleted.each {|path| attaches_discarded.push(path) }
-    end
-
-    def attaches_discard!(files)
-      files.reject!(&:blank?)
-      files.uniq!
-      if files.present?
-        logger.info "DELETE #{files.inspect}"
-        Utils.attache_delete(*files)
-      end
-    rescue Exception
-      raise if ENV['ATTACHE_DISCARD_FAILURE_RAISE_ERROR']
-      logger.warn [$!, $@]
-    end
-
     module ClassMethods
       def has_one_attache(name)
         serialize name, JSON
         define_method "#{name}_options",    -> (geometry, options = {}) { attache_field_options(self.send(name), geometry, Hash(multiple: false).merge(options)) }
         define_method "#{name}_url",        -> (geometry)               { attache_field_urls(self.send(name), geometry).try(:first) }
         define_method "#{name}_attributes", -> (geometry)               { attache_field_attributes(self.send(name), geometry).try(:first) }
-        define_method "#{name}=",           -> (value)                  { super(attache_field_set(Utils.array(value)).try(:first)) }
+        define_method "#{name}=",           -> (value)                  { super(attache_field_set(Array.wrap(value)).try(:first)) }
         after_update                        ->                          { self.attaches_discarded ||= []; attache_mark_for_discarding(self.send("#{name}_was"), self.send("#{name}"), self.attaches_discarded) }
         after_destroy                       ->                          { self.attaches_discarded ||= []; attache_mark_for_discarding(self.send("#{name}_was"), [], self.attaches_discarded) }
       end
@@ -95,7 +32,7 @@ module AttacheRails
         define_method "#{name}_options",    -> (geometry, options = {}) { attache_field_options(self.send(name), geometry, Hash(multiple: true).merge(options)) }
         define_method "#{name}_urls",       -> (geometry)               { attache_field_urls(self.send(name), geometry) }
         define_method "#{name}_attributes", -> (geometry)               { attache_field_attributes(self.send(name), geometry) }
-        define_method "#{name}=",           -> (value)                  { super(attache_field_set(Utils.array(value))) }
+        define_method "#{name}=",           -> (value)                  { super(attache_field_set(Array.wrap(value))) }
         after_update                        ->                          { self.attaches_discarded ||= []; attache_mark_for_discarding(self.send("#{name}_was"), self.send("#{name}"), self.attaches_discarded) }
         after_destroy                       ->                          { self.attaches_discarded ||= []; attache_mark_for_discarding(self.send("#{name}_was"), [], self.attaches_discarded) }
       end

--- a/lib/attache_rails/model.rb
+++ b/lib/attache_rails/model.rb
@@ -31,7 +31,7 @@ module AttacheRails
 
       def has_one_attache(name)
         attache_setup_column(name)
-        define_method "#{name}_options",    -> (geometry, options = {}) { attache_field_options(self.send(name), geometry, Hash(multiple: false).merge(options)) }
+        define_method "#{name}_options",    -> (geometry, options = {}) { Hash(class: 'enable-attache', multiple: false).merge(attache_field_options(self.send(name), geometry, options)) }
         define_method "#{name}_url",        -> (geometry)               { attache_field_urls(self.send(name), geometry).try(:first) }
         define_method "#{name}_attributes", -> (geometry)               { attache_field_attributes(self.send(name), geometry).try(:first) }
         define_method "#{name}=",           -> (value)                  { super(attache_field_set(Array.wrap(value)).try(:first)) }
@@ -41,7 +41,7 @@ module AttacheRails
 
       def has_many_attaches(name)
         attache_setup_column(name)
-        define_method "#{name}_options",    -> (geometry, options = {}) { attache_field_options(self.send(name), geometry, Hash(multiple: true).merge(options)) }
+        define_method "#{name}_options",    -> (geometry, options = {}) { Hash(class: 'enable-attache', multiple: true).merge(attache_field_options(self.send(name), geometry, options)) }
         define_method "#{name}_urls",       -> (geometry)               { attache_field_urls(self.send(name), geometry) }
         define_method "#{name}_attributes", -> (geometry)               { attache_field_attributes(self.send(name), geometry) }
         define_method "#{name}=",           -> (value)                  { super(attache_field_set(Array.wrap(value))) }

--- a/lib/attache_rails/version.rb
+++ b/lib/attache_rails/version.rb
@@ -1,3 +1,3 @@
 module AttacheRails
-  VERSION = "0.2.4"
+  VERSION = "0.3.0"
 end

--- a/lib/generators/attache_rails/templates/upgrade_v2_to_v3_migration.rb.erb
+++ b/lib/generators/attache_rails/templates/upgrade_v2_to_v3_migration.rb.erb
@@ -1,0 +1,45 @@
+class <%= migration_class_name %> < ActiveRecord::Migration
+  <%- ($has_one_attache + $has_many_attaches).each do |(klass, column)| -%>
+  class <%= klass %> < ActiveRecord::Base; serialize :<%= column %>, JSON; end
+  <%- end -%>
+
+  def self.up
+    # has_one_attache
+    <%- $has_one_attache.each do |(klass, column)| -%>
+    <%= klass %>.where.not(<%= column %>: [nil, ""]).find_each do |obj|
+      if obj[:<%= column %>].kind_of?(String)
+        obj.update(<%= column %>: JSON.parse(obj[:<%= column %>]))
+      end
+    end
+    <%- end -%>
+
+    # has_many_attaches
+    <%- $has_many_attaches.each do |(klass, column)| -%>
+    <%= klass %>.where.not(<%= column %>: [nil, ""]).find_each do |obj|
+      if obj[:<%= column %>].first.kind_of?(String)
+        obj.update(<%= column %>: obj[:<%= column %>].collect {|v| JSON.parse(v) })
+      end
+    end
+    <%- end -%>
+  end
+
+  def self.down
+    # has_one_attache
+    <%- $has_one_attache.each do |(klass, column)| -%>
+    <%= klass %>.where.not(<%= column %>: [nil, ""]).find_each do |obj|
+      if obj[:<%= column %>].kind_of?(Hash)
+        obj.update(<%= column %>: obj[:<%= column %>].to_json)
+      end
+    end
+    <%- end -%>
+
+    # has_many_attaches
+    <%- $has_many_attaches.each do |(klass, column)| -%>
+    <%= klass %>.where.not(<%= column %>: [nil, ""]).find_each do |obj|
+      if obj[:<%= column %>].first.kind_of?(Hash)
+        obj.update(<%= column %>: obj[:<%= column %>].collect {|v| v.to_json })
+      end
+    end
+    <%- end -%>
+  end
+end

--- a/lib/generators/attache_rails/upgrade_v2_to_v3_generator.rb
+++ b/lib/generators/attache_rails/upgrade_v2_to_v3_generator.rb
@@ -1,0 +1,55 @@
+require 'rails/generators/active_record'
+
+module AttacheRails
+  class UpgradeV2ToV3Generator < Rails::Generators::Base
+    include Rails::Generators::Migration
+
+    def self.next_migration_number(dir)
+      ActiveRecord::Generators::Base.next_migration_number(dir)
+    end
+
+    def self.source_root
+      @source_root ||= File.expand_path('../templates', __FILE__)
+    end
+
+    def generate_migration
+      migration_template "upgrade_v2_to_v3_migration.rb.erb", "db/migrate/#{migration_file_name}"
+    end
+
+    def migration_name
+      "UpgradeAttacheFieldsFromV2ToV3"
+    end
+
+    def migration_file_name
+      "#{migration_name.underscore}.rb"
+    end
+
+    def migration_class_name
+      migration_name.camelize
+    end
+
+    $has_one_attache = []
+    $has_many_attaches = []
+
+    ActiveRecord::Base.class_eval do
+      def self.has_one_attache(name)
+        $has_one_attache.push([self.name, name])
+      end
+
+      def self.has_many_attaches(name)
+        $has_many_attaches.push([self.name, name])
+      end
+    end
+
+    # Rails::ConsoleMethods#reload!
+    ActionDispatch::Reloader.cleanup!
+    ActionDispatch::Reloader.prepare!
+
+    ActiveRecord::Base.connection.tables.each do |table|
+      if klass = table.classify.safe_constantize
+      else
+        puts "skipped #{table}"
+      end
+    end
+  end
+end

--- a/spec/dummy/spec/models/product_spec.rb
+++ b/spec/dummy/spec/models/product_spec.rb
@@ -32,10 +32,10 @@ RSpec.describe Product, :type => :model do
     }
 
     describe 'hero_image=' do
-      it { expect { product.update(hero_image: attache_response) }.to change { product.hero_image }.to eq(attache_response) }
+      it { expect { product.update(hero_image: JSON.parse(attache_response)) }.to change { product.hero_image }.to eq(JSON.parse(attache_response)) }
       it { expect { product.update(hero_image: "")               }.not_to change { product.hero_image } }
       it { expect { product.update(hero_image: nil)              }.not_to change { product.hero_image } }
-      it { expect { product.update(hero_image: attache_fail)     }.not_to change { product.hero_image } }
+      it { expect { product.update(hero_image: JSON.parse(attache_fail))     }.not_to change { product.hero_image } }
 
       context 'accepts IO object' do
         before do
@@ -43,7 +43,7 @@ RSpec.describe Product, :type => :model do
           allow(HTTPClient).to receive(:post).and_return(double(:response, body: attache_response))
         end
 
-        it { expect { product.update(hero_image: file_io) }.to change { product.hero_image }.to eq(attache_response) }
+        it { expect { product.update(hero_image: file_io) }.to change { product.hero_image }.to eq(JSON.parse(attache_response)) }
       end
     end
 
@@ -107,13 +107,13 @@ RSpec.describe Product, :type => :model do
     }
 
     describe 'photos=' do
-      it { expect { product.update(photos: [attache_response]) }.to change { product.photos }.to eq([attache_response]) }
+      it { expect { product.update(photos: [JSON.parse(attache_response)]) }.to change { product.photos }.to eq([JSON.parse(attache_response)]) }
       it { expect { product.update(photos: [""])               }.to change { product.photos }.to eq([]) }
       it { expect { product.update(photos: [nil])              }.to change { product.photos }.to eq([]) }
       it { expect { product.update(photos: [])                 }.to change { product.photos }.to eq([]) }
       it { expect { product.update(photos: "")                 }.to change { product.photos }.to eq([]) }
       it { expect { product.update(photos: nil)                }.to change { product.photos }.to eq([]) }
-      it { expect { product.update(photos: [attache_fail])     }.to change { product.photos }.to eq([]) }
+      it { expect { product.update(photos: [JSON.parse(attache_fail)])     }.to change { product.photos }.to eq([]) }
 
       context 'accepts IO object' do
         before do
@@ -121,12 +121,12 @@ RSpec.describe Product, :type => :model do
           allow(HTTPClient).to receive(:post).and_return(double(:response, body: attache_response))
         end
 
-        it { expect { product.update(photos: [file_io]) }.to change { product.photos }.to eq([attache_response]) }
+        it { expect { product.update(photos: [file_io]) }.to change { product.photos }.to eq([JSON.parse(attache_response)]) }
       end
     end
 
     context 'with value' do
-      let(:product) { create(:product, photos: [attache_response]) }
+      let(:product) { create(:product, photos: [JSON.parse(attache_response)]) }
 
       it { expect(product.photos_attributes('geometry')).to eq([expected_attr_with_geometry]) }
       it { expect(product.photos_urls("geometry")).to eq([expected_attr_with_geometry['url']]) }
@@ -150,7 +150,7 @@ RSpec.describe Product, :type => :model do
           end
         end
 
-        it { product.update(photos: [other_attache_response]) }
+        it { product.update(photos: [JSON.parse(other_attache_response)]) }
         it { product.destroy }
       end
 
@@ -161,7 +161,7 @@ RSpec.describe Product, :type => :model do
           end
         end
 
-        it { product.update(attaches_discarded: [other_attache_response]) }
+        it { product.update(attaches_discarded: [JSON.parse(other_attache_response)]) }
       end
     end
   end

--- a/spec/dummy/spec/models/product_spec.rb
+++ b/spec/dummy/spec/models/product_spec.rb
@@ -32,10 +32,10 @@ RSpec.describe Product, :type => :model do
     }
 
     describe 'hero_image=' do
-      it { expect { product.update(hero_image: JSON.parse(attache_response)) }.to change { product.hero_image }.to eq(JSON.parse(attache_response)) }
+      it { expect { product.update(hero_image: attache_response) }.to change { product.hero_image }.to eq(JSON.parse(attache_response)) }
       it { expect { product.update(hero_image: "")               }.not_to change { product.hero_image } }
       it { expect { product.update(hero_image: nil)              }.not_to change { product.hero_image } }
-      it { expect { product.update(hero_image: JSON.parse(attache_fail))     }.not_to change { product.hero_image } }
+      it { expect { product.update(hero_image: attache_fail)     }.not_to change { product.hero_image } }
 
       context 'accepts IO object' do
         before do
@@ -107,13 +107,13 @@ RSpec.describe Product, :type => :model do
     }
 
     describe 'photos=' do
-      it { expect { product.update(photos: [JSON.parse(attache_response)]) }.to change { product.photos }.to eq([JSON.parse(attache_response)]) }
+      it { expect { product.update(photos: [attache_response]) }.to change { product.photos }.to eq([JSON.parse(attache_response)]) }
       it { expect { product.update(photos: [""])               }.to change { product.photos }.to eq([]) }
       it { expect { product.update(photos: [nil])              }.to change { product.photos }.to eq([]) }
       it { expect { product.update(photos: [])                 }.to change { product.photos }.to eq([]) }
       it { expect { product.update(photos: "")                 }.to change { product.photos }.to eq([]) }
       it { expect { product.update(photos: nil)                }.to change { product.photos }.to eq([]) }
-      it { expect { product.update(photos: [JSON.parse(attache_fail)])     }.to change { product.photos }.to eq([]) }
+      it { expect { product.update(photos: [attache_fail])     }.to change { product.photos }.to eq([]) }
 
       context 'accepts IO object' do
         before do
@@ -126,7 +126,7 @@ RSpec.describe Product, :type => :model do
     end
 
     context 'with value' do
-      let(:product) { create(:product, photos: [JSON.parse(attache_response)]) }
+      let(:product) { create(:product, photos: [attache_response]) }
 
       it { expect(product.photos_attributes('geometry')).to eq([expected_attr_with_geometry]) }
       it { expect(product.photos_urls("geometry")).to eq([expected_attr_with_geometry['url']]) }
@@ -150,7 +150,7 @@ RSpec.describe Product, :type => :model do
           end
         end
 
-        it { product.update(photos: [JSON.parse(other_attache_response)]) }
+        it { product.update(photos: [other_attache_response]) }
         it { product.destroy }
       end
 

--- a/spec/dummy/spec/models/product_spec.rb
+++ b/spec/dummy/spec/models/product_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Product, :type => :model do
 
       context 'accepts IO object' do
         before do
-          expect(AttacheRails::Utils).to receive(:attache_auth_options).and_return({})
+          expect(Attache::API::V1).to receive(:attache_auth_options).and_return({})
           allow(HTTPClient).to receive(:post).and_return(double(:response, body: attache_response))
         end
 
@@ -67,9 +67,9 @@ RSpec.describe Product, :type => :model do
 
       context 'discarding old values with auth_options' do
         before do
-          expect(AttacheRails::Utils).to receive(:attache_auth_options).and_return({})
+          expect(Attache::API::V1).to receive(:attache_auth_options).and_return({})
           expect(HTTPClient).to receive(:post_content) do |target_url, params|
-            expect(params).to eq(path)
+            expect(params).to eq(paths: path)
           end
         end
 
@@ -79,13 +79,13 @@ RSpec.describe Product, :type => :model do
 
       context 'discarding new values with auth_options' do
         before do
-          expect(AttacheRails::Utils).to receive(:attache_auth_options).and_return({})
+          expect(Attache::API::V1).to receive(:attache_auth_options).and_return({})
           expect(HTTPClient).to receive(:post_content) do |target_url, params|
-            expect(params).to eq(other_path)
+            expect(params).to eq(paths: other_path)
           end
         end
 
-        it { product.update(attaches_discarded: [other_attache_response]) }
+        it { product.update(attaches_discarded: [other_path]) }
       end
     end
   end
@@ -117,7 +117,7 @@ RSpec.describe Product, :type => :model do
 
       context 'accepts IO object' do
         before do
-          expect(AttacheRails::Utils).to receive(:attache_auth_options).and_return({})
+          expect(Attache::API::V1).to receive(:attache_auth_options).and_return({})
           allow(HTTPClient).to receive(:post).and_return(double(:response, body: attache_response))
         end
 
@@ -146,7 +146,7 @@ RSpec.describe Product, :type => :model do
       context 'discarding old values with auth_options' do
         before do
           expect(HTTPClient).to receive(:post_content) do |target_url, params|
-            expect(params).to eq(path)
+            expect(params).to eq(paths: path)
           end
         end
 
@@ -157,11 +157,11 @@ RSpec.describe Product, :type => :model do
       context 'discarding new values with auth_options' do
         before do
           expect(HTTPClient).to receive(:post_content) do |target_url, params|
-            expect(params).to eq(other_path)
+            expect(params).to eq(paths: other_path)
           end
         end
 
-        it { product.update(attaches_discarded: [JSON.parse(other_attache_response)]) }
+        it { product.update(attaches_discarded: [other_path]) }
       end
     end
   end


### PR DESCRIPTION
- Core library code moved to https://github.com/choonkeat/attache_api (code here is specific to ActiveRecord)
- Add support for `:json` column
  - Changed to work with `Hash` and `[Hash, Hash]` instead of `String` and `[String, String]`
