### PR TITLE
Delete unused constants in `lib/attache/rails.rb`

### DIFF
--- a/lib/attache/rails.rb
+++ b/lib/attache/rails.rb
@@ -1,10 +1,5 @@
 module Attache
   module Rails
-    ATTACHE_URL             = ENV.fetch('ATTACHE_URL')             { "http://localhost:9292" }
-    ATTACHE_UPLOAD_URL      = ENV.fetch('ATTACHE_UPLOAD_URL')      { "#{ATTACHE_URL}/upload" }
-    ATTACHE_DOWNLOAD_URL    = ENV.fetch('ATTACHE_DOWNLOAD_URL')    { "#{ATTACHE_URL}/view" }
-    ATTACHE_DELETE_URL      = ENV.fetch('ATTACHE_DELETE_URL')      { "#{ATTACHE_URL}/delete" }
-    ATTACHE_UPLOAD_DURATION = ENV.fetch('ATTACHE_UPLOAD_DURATION') { 3.hours }.to_i # expires signed upload form
   end
 end
 


### PR DESCRIPTION
These constants are defined here: https://github.com/choonkeat/attache-api/blob/master/lib/attache/api/v1.rb#L12

And there's no place in the code reference to these constants
