### PR TITLE
Move AR extensions to rails initialize step

### DIFF
--- a/lib/attache/rails.rb
+++ b/lib/attache/rails.rb
@@ -5,5 +5,5 @@ end
 
 require "attache/rails/engine"
 require "attache/rails/model"
-require 'attache/rails/railtie' if defined? ::Rails::Railtie
+require 'attache/rails/railtie'
 require "attache/api/test" if defined?(Rails) && Rails.env.test?

--- a/lib/attache/rails.rb
+++ b/lib/attache/rails.rb
@@ -5,4 +5,5 @@ end
 
 require "attache/rails/engine"
 require "attache/rails/model"
+require 'attache/rails/railtie' if defined? ::Rails::Railtie
 require "attache/api/test" if defined?(Rails) && Rails.env.test?

--- a/lib/attache/rails/model.rb
+++ b/lib/attache/rails/model.rb
@@ -57,5 +57,3 @@ module Attache
     end
   end
 end
-
-ActiveRecord::Base.send(:include, Attache::Rails::Model)

--- a/lib/attache/rails/railtie.rb
+++ b/lib/attache/rails/railtie.rb
@@ -1,0 +1,11 @@
+require 'rails'
+
+module Attache
+  module Rails
+    class Attache::Rails::Railtie < ::Rails::Railtie
+      initializer "attache-rails.configure" do |app|
+        ActiveRecord::Base.send(:include, Attache::Rails::Model)
+      end
+    end
+  end
+end


### PR DESCRIPTION
@choonkeat - Hey, ran into a small bug of sorts with this gem so figured I'd open a PR while I had it figured out. Not sure if you're planning to continue maintaining these gems, if not I can just run with forks under the gimmie account, no problem.

Anyways, issue was that I kept getting this damn warning every time I started gimmie:

```
DEPRECATION WARNING: Currently, Active Record suppresses errors raised within `after_rollback`/`after_commit` callbacks and only print them to the logs. In the next version, these errors will no longer be suppressed. Instead, the errors will propagate normally just like in other Active Record callbacks.

You can opt into the new behavior and remove this warning by setting:

  config.active_record.raise_in_transactional_callbacks = true

 (called from <top (required)> at /home/john/workspace/gimmie/config/application.rb:7)
```

That line is where bundle requires all the gems. I commented out gems until I figured out it was `attache-rails`, and looked through the code until I found the reference to ActiveRecord::Base at the end of that `Model` file.

So I added a `Railtie` and moved it there and that seems to fix it. Might be better to remove the `if defined?(Rails::Railtie)` since this is a very rails-specific gem... Actually yeah I'm going to add another commit to remove that since if this loaded before rails did then it wouldn't set the initializer so we should force rails to load.

See https://github.com/rails/rails/issues/18084
