### PR TITLE
Fix specs raise error with rails 5.1

### DIFF
--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -18,8 +18,5 @@ module Dummy
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
-
-    # Do not swallow errors in after_commit/after_rollback callbacks.
-    config.active_record.raise_in_transactional_callbacks = true
   end
 end


### PR DESCRIPTION
rails 5.1 no longer has `raise_in_transactional_callbacks=`

```
Failure/Error: ActiveRecord::Base.send(:include, Attache::Rails::Model)
NoMethodError:
  undefined method `raise_in_transactional_callbacks=' for ActiveRecord::Base:Class
```